### PR TITLE
Corrected the capitalization of PrebuiltQueries.json

### DIFF
--- a/src/components/SearchContainer/Tabs/PrebuiltQueriesDisplay.jsx
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueriesDisplay.jsx
@@ -13,7 +13,7 @@ export default class PrebuiltQueriesDisplay extends Component {
 
     componentWillMount() {
         $.ajax({
-            url: 'src/components/SearchContainer/Tabs/prebuiltqueries.json',
+            url: 'src/components/SearchContainer/Tabs/PrebuiltQueries.json',
             type: 'GET',
             success: function(response){
                 var x = JSON.parse(response)
@@ -23,7 +23,7 @@ export default class PrebuiltQueriesDisplay extends Component {
                     y.push(el)
                 });
 
-                this.setState({queries: y})    
+                this.setState({queries: y})
             }.bind(this)
         })
     }


### PR DESCRIPTION
The capitalization of the filename url did not match the file itself, this caused the Pre-Built Queries to not load on OS x.