### PR TITLE
Add additional check for empty SID parameter

### DIFF
--- a/PowerShell/BloodHound.ps1
+++ b/PowerShell/BloodHound.ps1
@@ -14555,7 +14555,9 @@ function Export-BloodHoundCSV {
             }
         }
         elseif($Object.PSObject.TypeNames -contains 'PowerView.GPOLocalGroup') {
-            $MemberSimpleName = Convert-SidToName -SID $Object.ObjectSID | Convert-ADName -InputType 'NT4' -OutputType 'Canonical'
+            if(![string]::IsNullOrEmpty($Object.SID)){
+                $MemberSimpleName = Convert-SidToName -SID $Object.ObjectSID | Convert-ADName -InputType 'NT4' -OutputType 'Canonical'
+            }
 
             if($MemberSimpleName) {
                 $MemberDomain = $MemberSimpleName.Split('/')[0]


### PR DESCRIPTION
This is to fix an issue similar to issue #38, but at a different location. I ran into this error trying to run Get-BloodHoundData on a medium-sized domain.

> WARNING: The pipeline has been stopped.
> Convert-SidToName : Cannot validate argument on parameter 'SID'. The argument "" does not match the "^S-1-.\*" pattern. Supply an argument that matches "^S-1-.\*" and try the command again.
> At C:\Users\superadmin\BloodHound.ps1:14556 char:55
> \+             $MemberSimpleName = Convert-SidToName -SID <<<<  $Object.ObjectSID | Convert-ADName -InputType 'NT4' -OutputType 'Canonical'
>     \+ CategoryInfo          : InvalidData: (:) [Convert-SidToName], ParameterBindingValidationException
>     \+ FullyQualifiedErrorId : ParameterArgumentValidationError,Convert-SidToName
